### PR TITLE
fix: stones don't apply any gravity to their own squares

### DIFF
--- a/voronoi_game.py
+++ b/voronoi_game.py
@@ -152,12 +152,13 @@ class VoronoiGame:
     # note: score ignores stones, because each player has the same number of stones
     for row in range(self.grid_size):
       for col in range(self.grid_size):
-        # avoid division by 0
+        # FIX: stone should applies a pull of 1 to its own square
         if (row == move_row and col == move_col):
-          continue
+          self.pull[self.current_player][row][col] = 1
         # update current player's pull
-        d = self.__compute_distance(row, col, move_row, move_col)
-        self.pull[self.current_player][row][col] += float(float(1) / (d*d))
+        else:
+          d = self.__compute_distance(row, col, move_row, move_col)
+          self.pull[self.current_player][row][col] += float(float(1) / (d*d))
 
         # first move claims every cell on the grid
         if self.moves_made == 1:

--- a/voronoi_game.py
+++ b/voronoi_game.py
@@ -157,8 +157,9 @@ class VoronoiGame:
           self.pull[self.current_player][row][col] = 1
         # update current player's pull
         else:
-          d = self.__compute_distance(row, col, move_row, move_col)
-          self.pull[self.current_player][row][col] += float(float(1) / (d*d))
+          # FIX: replace power and sqrt with abs to speed up computation
+          #  because sqrt(d) * sqrt(d) = abs(d)
+          self.pull[self.current_player][row][col] += float(float(1) / abs((move_row - row)**2 + (move_col - col)**2))
 
         # first move claims every cell on the grid
         if self.moves_made == 1:


### PR DESCRIPTION
With the current Gravitational Voronoi Game architecture, stones don't apply any gravity to their own squares. For example, in this 5x5 grid, if RED places a stone at (3,3), the pull at (3,3) remains 0 while all other points have a positive pull.
![image](https://user-images.githubusercontent.com/23471930/200140195-5b089a03-6dee-444a-a37c-71e58341e7bb.png)
After BLUE places a stone at (0,2), BLUE in fact occupies (3,3) while RED occupies (0,2)
![image](https://user-images.githubusercontent.com/23471930/200140199-bdd26c6f-f8e3-448a-936f-3044a2b17682.png)

The expected behavior is that RED occupies (3,3) where it placed a stone, while BLUE occupies (0,2).
![image](https://user-images.githubusercontent.com/23471930/200140224-de85eace-9bbf-46c3-a03b-6848455ce8c7.png)

This PR also replaces `sqrt(d) * sqrt(d)` with `abs(d)` to speed up computation.
